### PR TITLE
Add back note that shortname will be generated.

### DIFF
--- a/.github/ISSUE_TEMPLATE/session.yml
+++ b/.github/ISSUE_TEMPLATE/session.yml
@@ -43,7 +43,7 @@ body:
     attributes:
       label: IRC channel (Optional)
       description: |
-        Shortname for the irc.w3.org channel (e.g., `my-fav-session`)
+        Shortname for the irc.w3.org channel (e.g., `my-fav-session`). If not provided, shortname will be generated from title.
     validations:
       required: false
 


### PR DESCRIPTION
 Otherwise people might wonder whether they will only get an IRC channel if they provide a name.